### PR TITLE
Added the functionality of creating a key pair based off of account numb...

### DIFF
--- a/ripple-core/src/main/java/com/ripple/core/coretypes/AccountID.java
+++ b/ripple-core/src/main/java/com/ripple/core/coretypes/AccountID.java
@@ -1,19 +1,20 @@
 package com.ripple.core.coretypes;
 
-import static com.ripple.config.Config.getB58IdentiferCodecs;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import com.ripple.core.serialized.*;
-import com.ripple.encodings.common.B16;
-
-import com.ripple.core.fields.Field;
-import com.ripple.core.fields.TypedFields;
+import static com.ripple.config.Config.getB58IdentiferCodecs;
 import com.ripple.core.coretypes.hash.Hash160;
 import com.ripple.core.coretypes.uint.UInt32;
+import com.ripple.core.fields.Field;
+import com.ripple.core.fields.TypedFields;
+import com.ripple.core.serialized.BinaryParser;
+import com.ripple.core.serialized.BytesSink;
+import com.ripple.core.serialized.SerializedType;
+import com.ripple.core.serialized.TypeTranslator;
 import com.ripple.crypto.ecdsa.IKeyPair;
 import com.ripple.crypto.ecdsa.Seed;
+import com.ripple.encodings.common.B16;
 import com.ripple.utils.Utils;
 
 public class AccountID implements SerializedType, Comparable<AccountID> {
@@ -86,7 +87,7 @@ public class AccountID implements SerializedType, Comparable<AccountID> {
     }
 
     public static IKeyPair keyPairFromSeedBytes(byte[] master_seed) {
-        return Seed.createKeyPair(master_seed);
+        return Seed.createKeyPairFromSeedBytes(master_seed);
     }
 
     public IKeyPair getKeyPair() {

--- a/ripple-core/src/main/java/com/ripple/crypto/ecdsa/Seed.java
+++ b/ripple-core/src/main/java/com/ripple/crypto/ecdsa/Seed.java
@@ -1,14 +1,17 @@
 package com.ripple.crypto.ecdsa;
 
-import com.ripple.utils.Utils;
-
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 
 import static com.ripple.utils.Utils.halfSha512;
 import static com.ripple.utils.Utils.quarterSha512;
+import com.ripple.utils.Utils;
 
 public class Seed {
+
+    private static final BigInteger ORDER = SECP256K1.order();
+    private static final int DEFAULT_SEQ = 0;
+
     public static byte[] passPhraseToSeedBytes(String seed) {
         try {
             return quarterSha512(seed.getBytes("utf-8"));
@@ -17,35 +20,70 @@ public class Seed {
         }
     }
 
-    public static IKeyPair createKeyPair(byte[] seedBytes) {
-        BigInteger secret, pub, privateGen, order = SECP256K1.order();
-        byte[] privateGenBytes;
-        byte[] publicGenBytes;
+    public static IKeyPair createKeyPairFromAccountNumber(String seedStr, int accountNumber) {
+        BigInteger privateGen = createPrivateGen(passPhraseToSeedBytes(seedStr));
+        byte[] publicGenBytes = SECP256K1.basePointMultipliedBy(privateGen);
 
-        int i = 0, seq = 0;
+        return createKeyPair(publicGenBytes, accountNumber, privateGen);
+    }
+
+    public static IKeyPair createKeyPairFromAddress(String seedStr, BigInteger address) {
+        IKeyPair keyPair;
+        int maxLoops = 1000;
+        BigInteger privateGen = createPrivateGen(passPhraseToSeedBytes(seedStr));
+        byte[] publicGenBytes = SECP256K1.basePointMultipliedBy(privateGen);
 
         while (true) {
-            privateGenBytes = hashedIncrement(seedBytes, i++);
-            privateGen = Utils.uBigInt(privateGenBytes);
-            if (privateGen.compareTo(order) == -1) {
+            keyPair = createKeyPair(publicGenBytes, 0, privateGen);
+
+            if (--maxLoops == 0) {
+                throw new RuntimeException("Too many loops looking for KeyPair yielding: " + address);
+            }
+            if (true /*address == ? (Still trying to figure out)*/) {
                 break;
             }
         }
-        publicGenBytes = SECP256K1.basePointMultipliedBy(privateGen);
+        return keyPair;
+    }
 
-        i=0;
+    public static IKeyPair createKeyPairFromSeedBytes(byte[] seedBytes) {
+        BigInteger privateGen = createPrivateGen(seedBytes);
+        byte[] publicGenBytes = SECP256K1.basePointMultipliedBy(privateGen);
+
+        return createKeyPair(publicGenBytes, DEFAULT_SEQ, privateGen);
+    }
+
+    private static IKeyPair createKeyPair(byte[] publicGenBytes, int seq, BigInteger privateGen) {
+        BigInteger secret;
+
+        int i = 0;
         while (true) {
             byte[] secretBytes = hashedIncrement(appendIntBytes(publicGenBytes, seq), i++);
             secret = Utils.uBigInt(secretBytes);
-            if (secret.compareTo(order) == -1) {
+            if (secret.compareTo(ORDER) == -1) {
                 break;
             }
         }
 
-        secret = secret.add(privateGen).mod(order);
-        pub = Utils.uBigInt(SECP256K1.basePointMultipliedBy(secret));
+        secret = secret.add(privateGen).mod(ORDER);
+        BigInteger pub = Utils.uBigInt(SECP256K1.basePointMultipliedBy(secret));
 
         return new KeyPair(secret, pub);
+    }
+
+    private static BigInteger createPrivateGen(byte[] seedBytes) {
+        BigInteger privateGen;
+        byte[] privateGenBytes;
+
+        int i = 0;
+        while (true) {
+            privateGenBytes = hashedIncrement(seedBytes, i++);
+            privateGen = Utils.uBigInt(privateGenBytes);
+            if (privateGen.compareTo(ORDER) == -1) {
+                break;
+            }
+        }
+        return privateGen;
     }
 
     private static byte[] hashedIncrement(byte[] bytes, int increment) {

--- a/ripple-core/src/test/java/com/ripple/core/KeyPairTest.java
+++ b/ripple-core/src/test/java/com/ripple/core/KeyPairTest.java
@@ -1,24 +1,22 @@
 package com.ripple.core;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import com.ripple.core.coretypes.AccountID;
+import com.ripple.crypto.ecdsa.IKeyPair;
 import com.ripple.crypto.ecdsa.KeyPair;
+import com.ripple.crypto.ecdsa.Seed;
 import com.ripple.encodings.common.B16;
 import org.json.JSONArray;
 import org.junit.Test;
 import org.ripple.bouncycastle.util.encoders.Hex;
 
-import com.ripple.core.coretypes.AccountID;
-import com.ripple.crypto.ecdsa.IKeyPair;
-import com.ripple.crypto.ecdsa.Seed;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-
 public class KeyPairTest {
-    IKeyPair keyPair = Seed.createKeyPair(TestFixtures.master_seed_bytes);
+    IKeyPair keyPair = Seed.createKeyPairFromSeedBytes(TestFixtures.master_seed_bytes);
 
     @Test
     public void testVerify() {


### PR DESCRIPTION
...er or account address as well as from seed bytes.

After thinking about it more and a few of sublimator's comments,I came to the realization that the java version shouldn't mirror the exact behavior of the JS function (because of the different nature of the languages).  

Because of the strong typing nature of Java I thought it would be best to let the client of the Seed class determine which method / case they would like to use and eliminate any ambiguity in letting the function determine what the client is sending in.  

TODO: Find out exactly what the check should be in the createKeyPairFromAddress should 
